### PR TITLE
Convert domain_descriptors into a struct

### DIFF
--- a/test/discretizations.jl
+++ b/test/discretizations.jl
@@ -8,17 +8,16 @@
     @testset "Domain descriptors" begin
         domain_descriptors = generate_domain_and_filters(b, II, N)
 
-        domain_range,
-        interpolation_matrix,
-        (N, II, J),
-        (X, x, ref_x),
-        (Omega, omega),
-        (W, R),
-        (IP, ip, ref_ip),
-        (INTEG, integ, ref_integ) = domain_descriptors
+        W = domain_descriptors.W
+        R = domain_descriptors.R
+        II = domain_descriptors.I
+        N = domain_descriptors.N
 
         @test size(W) == (II, N)
         @test size(R) == (N, II)
+
+        Omega = domain_descriptors.volumes.coarse
+        omega = domain_descriptors.volumes.fine
         @test size(Omega) == (II, II)
         @test size(omega) == (N, N)
 
@@ -34,6 +33,8 @@
         # filtered
         u_bar = W * u
         v_bar = W * v
+        IP = domain_descriptors.inner_products.coarse
+        ip = domain_descriptors.inner_products.fine
         # Eq. (A.1) (with a and b in the paper replaced by u and v here)
         @test ip(R * u_bar, R * v_bar) ≈ IP(u_bar, v_bar)
 


### PR DESCRIPTION
This is an example of the type of refactorings I think must be done, here on a small scale focussing on the `domain_descriptors` that was passed around everywhere.
The important part of this refactor is copied here for convenience, all other changes are just so that they become compatible with this structure.

I have rewritten the tuple as a struct, which contains other structs. I think this is useful on its own, it makes it a lot more readable, and after doing this it also becomes clearer that many functions actually don't need the whole `domain_descriptors` but only a few parts.

But more importantly this is I think something we should do at a large scale, that is, create a type for a closure model, and for an equation, and for a solver, etc. Finding the best way to decompose things in this way is not easy and will require probably several iterations (what I did for the `DomainDescriptors` can certainly be improved), but I think this is the core of what we should do to make everything modular, and possibly compatible with SciML.

```julia
"""
General type for triples of types, one for the fine grid, one for the coarse grid and one for the reference grid.
"""
struct Triplet{T}
    coarse::T
    fine::T
    reference::T
end

Grid = Vector{Float64}
Volume = Matrix{Float64}
InnerProduct = Function
Integrator = Function

struct DomainDescriptors
    b::Float64
    interpolation_matrix::SparseMatrixCSC{Float64,Int}
    N::Int
    I::Int
    J::Int
    W::SparseMatrixCSC{Float64,Int}
    R::SparseMatrixCSC{Float64,Int}
    grids::Triplet{Grid}
    volumes::Triplet{Volume}
    inner_products::Triplet{InnerProduct}
    integrators::Triplet{Integrator}
end
```